### PR TITLE
better resolve circular dependency

### DIFF
--- a/src/gifcodec.js
+++ b/src/gifcodec.js
@@ -2,10 +2,15 @@
 
 const Omggif = require('omggif');
 const { Gif, GifError } = require('./gif');
-let GifUtil; // allow circular dependency with GifUtil
-process.nextTick(() => {
-    GifUtil = require('./gifutil');
-});
+
+let GifUtil;
+
+const getGifUtil = () => {
+    if (!GifUtil) {
+        GifUtil = require('./gifutil');
+    }
+    return GifUtil;
+};
 
 const { GifFrame } = require('./gifframe');
 
@@ -95,7 +100,7 @@ class GifCodec
             if (frames === null || frames.length === 0) {
                 throw new GifError("there are no frames");
             }
-            const dims = GifUtil.getMaxDimensions(frames);
+            const dims = getGifUtil().getMaxDimensions(frames);
 
             spec = Object.assign({}, spec); // don't munge caller's spec
             spec.width = dims.maxWidth;
@@ -170,10 +175,10 @@ class GifCodec
     _encodeGif(frames, spec) {
         let colorInfo;
         if (spec.colorScope === Gif.LocalColorsOnly) {
-            colorInfo = GifUtil.getColorInfo(frames, 0);
+            colorInfo = getGifUtil().getColorInfo(frames, 0);
         }
         else {
-            colorInfo = GifUtil.getColorInfo(frames, 256);
+            colorInfo = getGifUtil().getColorInfo(frames, 256);
             if (!colorInfo.colors) { // if global palette impossible
                 if (spec.colorScope === Gif.GlobalColorsOnly) {
                     throw new GifError(


### PR DESCRIPTION
For context, I am trying to use gifwrap (via jimp) in a V8 environment where some node/browser components are not available by default. `process.nextTick` is one of those that have a different behavior from the nodejs environment. 

This PR uses a dynamic require to avoid circular dependency but removes the dependency on process.nextTick. I have tested in a few calls. 