### PR TITLE
Update image-q dependency to 4.0.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/jtlapp/gifwrap#readme",
   "dependencies": {
-    "image-q": "^1.1.1",
+    "image-q": "^4.0.0",
     "omggif": "^1.0.10"
   },
   "devDependencies": {

--- a/src/gifutil.js
+++ b/src/gifutil.js
@@ -332,11 +332,11 @@ function _quantize(imageOrImages, method, maxColorIndexes, modifier, dither) {
         inputContainers.push(inputContainer);
     });
     
-    const limitedPalette = quantizer.quantize();
+    const limitedPalette = quantizer.quantizeSync();
 
     for (let i = 0; i < images.length; ++i) {
         const imageBuf = images[i].bitmap.data;
-        const outputContainer = imageMaker.quantize(inputContainers[i], limitedPalette);
+        const outputContainer = imageMaker.quantizeSync(inputContainers[i], limitedPalette);
         const outputArray = outputContainer.toUint32Array();
         for (let bi = 0, ai = 0; bi < imageBuf.length; bi += 4, ++ai) {
             imageBuf.writeUInt32LE(outputArray[ai], bi);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/node@16.9.1":
+  version "16.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
+  integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -454,9 +459,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-image-q@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/image-q/-/image-q-1.1.1.tgz#fc84099664460b90ca862d9300b6bfbbbfbf8056"
+image-q@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/image-q/-/image-q-4.0.0.tgz#31e075be7bae3c1f42a85c469b4732c358981776"
+  integrity sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==
+  dependencies:
+    "@types/node" "16.9.1"
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
My primary motivation is reduction of `node_modules` as image-q in version 1 contains some some big image files as part of distribution.