### PR TITLE
Update encodeGif types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ export class GifCodec implements GifEncoder, GifDecoder {
 
     constructor(options?: GifCodecOptions);
 
-    encodeGif(frames: GifFrame[], spec: GifSpec): Promise<Gif>;
+    encodeGif(frames: GifFrame[], spec?: GifSpec): Promise<Gif>;
     decodeGif(buffer: Buffer): Promise<Gif>;
 }
 


### PR DESCRIPTION
as said [in the docs](https://github.com/jtlapp/gifwrap#gifcodecencodegifframes-spec) the encode spec in encodeGif is actually optional